### PR TITLE
Fixed Music Album Covers not displaying on RPC

### DIFF
--- a/AlbumCoverFetcher.py
+++ b/AlbumCoverFetcher.py
@@ -1,54 +1,63 @@
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 def get_song_album_cover_url(artist: str, album: str) -> str | None:
-    """
-    Returns the best available album cover image URL (front cover) for a given artist and album.
-    Falls back from thumbnail to full image if needed.
-    """
+    session = requests.Session()
+    
     headers = {
-        "User-Agent": "AlbumCoverFetcher/1.0 (your_email@example.com)"
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) JellyfinRPC/1.0",
+        "Connection": "close" 
     }
 
-    # Step 1: Search MusicBrainz
+    
+    retry_strategy = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("https://", adapter)
+
+    
     mb_url = "https://musicbrainz.org/ws/2/release/"
     params = {
-        "query": f'release:{album} AND artist:{artist}',
+        "query": f'release:"{album}" AND artist:"{artist}"', 
         "fmt": "json"
     }
 
     try:
-        mb_resp = requests.get(mb_url, headers=headers, params=params)
+        mb_resp = session.get(mb_url, headers=headers, params=params, timeout=10)
         mb_resp.raise_for_status()
-        releases = mb_resp.json().get("releases", [])
+        
+        data = mb_resp.json()
+        releases = data.get("releases", [])
+        
         if not releases:
-            print("No releases found.")
             return None
+            
         mbid = releases[0]["id"]
     except Exception as e:
-        print("MusicBrainz error:", e)
+        # We log this, but main.py will now stay alive
+        print(f"MusicBrainz API unreachable: {e}")
         return None
 
     # Step 2: Check cover art availability
     caa_url = f"https://coverartarchive.org/release/{mbid}"
     try:
-        caa_resp = requests.get(caa_url, headers=headers)
+        caa_resp = session.get(caa_url, headers=headers, timeout=10)
         caa_resp.raise_for_status()
+        
         images = caa_resp.json().get("images", [])
         for img in images:
             if img.get("front"):
+               
                 return img.get("thumbnails", {}).get("large") or img.get("image")
-        print("No front image found.")
+                
+    except Exception:
+        # If no cover art exists, CAA returns 404, which is handled here
         return None
-    except requests.exceptions.HTTPError as e:
-        if e.response.status_code == 404:
-            print("No cover art found for this release.")
-        else:
-            print("CAA HTTP error:", e)
-        return None
-    except Exception as e:
-        print("Error fetching cover art:", e)
-        return None
+    finally:
+        session.close() # Explicitly close the session
 
-# 🔍 Test
-#url = get_album_cover_url("Boards of Canada", "Music Has the Right to Children")
-#print("Cover URL:", url)
+    return None

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 import os
 from AlbumCoverFetcher import get_song_album_cover_url
 
-# TODO: log cleaning <-after certain date? certain amount of logs?
+
 load_dotenv()
 
 # Setup logging
@@ -130,6 +130,7 @@ def extract_now_playing(sessions):
 
         title = now_playing.get("Name", "Unknown Media")
 
+        # --- Logic for Audio ---
         if media_type == "Audio":
             title = now_playing.get("Name", "Unknown Track")
             artists = [
@@ -144,6 +145,7 @@ def extract_now_playing(sessions):
             details = title
             state = f"by {', '.join(artists)} from {album}"
 
+        # --- Logic for Movies ---
         elif media_type == "Movie":
             title = now_playing.get("Name", "Unknown Movie")
             year = now_playing.get("ProductionYear")
@@ -152,6 +154,7 @@ def extract_now_playing(sessions):
             details = title
             state = f"{year} • {', '.join(genres)}" if year and genres else "Movie"
 
+        # --- Logic for TV Episodes ---
         elif media_type == "Episode":
             series_name = now_playing.get("SeriesName", "Unknown Series")
             season_number = now_playing.get("ParentIndexNumber")
@@ -166,13 +169,27 @@ def extract_now_playing(sessions):
             details = title
             state = media_type
 
-        album_cover_url = get_album_cover_url(now_playing)
+        # --- IMAGE FETCHING LOGIC ---
+        album_cover_url = default_image_url  # Start with fallback
+        
+        if media_type == "Audio":
+            try:
+                # Use the imported music fetcher
+                artist_query = ", ".join(artists) if artists else "Unknown Artist"
+                fetched_url = get_song_album_cover_url(artist_query, album)
+                if fetched_url:
+                    album_cover_url = fetched_url
+            except Exception as e:
+                logging.error(f"MusicBrainz Error: {e}")
+                # Keep the default if fetcher fails
+        
+        elif media_type in ["Movie", "Episode"]:
+            # Use your local OMDB function
+            album_cover_url = get_album_cover_url(now_playing)
+
         is_paused = play_state.get("IsPaused", False)
         is_muted = play_state.get("IsMuted", False)
         client = session.get("Client", "Unknown Client")
-        if media_type == "Audio":
-            album_cover_url = get_song_album_cover_url("".join(artists), album)
-            print(album_cover_url)
 
         media_info = {
             "Type": media_type,
@@ -190,6 +207,7 @@ def extract_now_playing(sessions):
             "ExternalUrls": now_playing.get("ExternalUrls", []),
         }
 
+        # Update metadata based on type
         if media_type == "Audio":
             media_info.update({"Artists": artists, "Album": album})
         elif media_type == "Movie":


### PR DESCRIPTION
Fixed the image fetching logic for audio types. Only uses MusicBrains for audio images. Additionally, fixed the MusicBrains API 
call using an invalid header and the retry logic for API calls.